### PR TITLE
Abort Controller Implementation plus some cleanup.

### DIFF
--- a/front-end/src/components/LoginForm.tsx
+++ b/front-end/src/components/LoginForm.tsx
@@ -214,7 +214,6 @@ export default function LoginForm(props: any) {
                                                 path: '/',
                                             })
                                             cookies.set('user_id', response.data['user_id'])
-                                            console.log(response.data)
                                             props.close()
                                             props.login()
                                         }

--- a/front-end/src/components/table/AnalystCallTable.tsx
+++ b/front-end/src/components/table/AnalystCallTable.tsx
@@ -6,6 +6,7 @@ import TableContainer from '@mui/material/TableContainer'
 import TableHead from '@mui/material/TableHead'
 import TableRow from '@mui/material/TableRow'
 import Paper from '@mui/material/Paper'
+import { getControllerSignal } from '../../config/WebcallAPI'
 
 function createData(symbol: string, buy: number, hold: number, period: string, sell: number, strongBuy: number, strongSell: number) {
     return {symbol, buy, hold, period, sell, strongBuy, strongSell}
@@ -14,7 +15,8 @@ function createData(symbol: string, buy: number, hold: number, period: string, s
 export default function AnalystCallTable() {
     const [analystCalls, setAnalystCalls] = useState([])
     useEffect(() => {
-        fetch('http://127.0.0.1:8080/analystCallsDefaultList')
+        const signal = getControllerSignal()
+        fetch('http://127.0.0.1:8080/analystCallsDefaultList',{signal})
             .then((response) => response.json())
             .then((data) => {
                 setAnalystCalls(data)

--- a/front-end/src/components/table/InsiderTradeTable.tsx
+++ b/front-end/src/components/table/InsiderTradeTable.tsx
@@ -1,5 +1,5 @@
 import axios from "axios"
-import { getInsiderTrades } from "../../config/WebcallAPI"
+import { getControllerSignal, getInsiderTrades } from "../../config/WebcallAPI"
 import { Box, Button, Table, TableBody, TableCell, TableContainer, TableHead, TableRow, Typography, styled } from "@mui/material"
 import { useEffect, useState } from "react"
 import LoadingBox from "../general/LoadingBox"
@@ -79,16 +79,26 @@ export default function InsiderTradeTable (props: {ticker:string}){
     const[dataToggle,setDataToggle] = useState(false)
     const[numPages, setNumPages] = useState(1)
     const[currentPage,setCurrentPage]=useState(1)
+    let key = 1;
+
+    const generateUniqueKey = ()=>{
+        let val = key
+        key += 1
+        return val
+    }
 
     useEffect(()=>{
-        axios.get(getInsiderTrades(currentPage,props.ticker)).then((response)=>{
+        axios.get(getInsiderTrades(currentPage,props.ticker),{signal:getControllerSignal()}).then((response)=>{
             setData(response.data[0]['data'])
-            console.log(response)
             if(response.data[0]['num_pages'] !== numPages)setNumPages(response.data[0]['num_pages'])
             setDataReady(true)
         }).catch((error)=>{
-            setDataReady(false)
-            setDataToggle(!dataToggle)
+            if(error.message !== 'canceled'){
+                setDataReady(false)
+                setDataToggle(!dataToggle)
+            }
+            else console.log(error)
+            
         })
         
     },[dataToggle,currentPage,props.ticker])
@@ -113,7 +123,7 @@ export default function InsiderTradeTable (props: {ticker:string}){
                     </TableHead>
                     <TableBody>
                     {data.map((row)=>(
-                        <TableRow>
+                        <TableRow key={generateUniqueKey()}>
                             <TableCell>{row['filingDate']}</TableCell>
                             <TableCell align="center">{row['transactionDate']}</TableCell>
                             <TableCell align="center">{row['symbol']}</TableCell>
@@ -121,7 +131,6 @@ export default function InsiderTradeTable (props: {ticker:string}){
                             <TableCell align="center">{new Intl.NumberFormat().format((row['change']as number))}</TableCell>
                             <TableCell align="center">{row['name']}</TableCell>
                         </TableRow>
-                            
                         ))}
                     </TableBody>
                 </Table>

--- a/front-end/src/config/WebcallAPI.tsx
+++ b/front-end/src/config/WebcallAPI.tsx
@@ -1,4 +1,31 @@
 const backendBaseAddress = 'http://127.0.0.1:8080'
+var controller = new AbortController();
+
+//////////// CONTROLLER CALLS ////////////
+
+/*
+    abortRequest should be called when a new component first mounts, before
+    it makes any fetch requests. We do not want to pass our controller directly,
+    it needs to operate in a singleton state so that we can pass references of it
+    around as needed to our components.
+
+    All fetch/axios requests that can be interrupted need to get the controller signal 
+    EX:
+        const signal = getControllerSignal()
+        await fetch(getUserWL(cookies.get('user_id')), {signal})
+
+                OR
+
+        axios.get(getUserData(cookies.get('user')),{signal:getControllerSignal()})
+*/
+
+export function getControllerSignal(){
+    return controller.signal
+}
+export function abortRequest(){
+    controller.abort();
+    controller = new AbortController();
+}
 
 //////////// LOGIN CALLS ////////////
 

--- a/front-end/src/scenes/LandingPage.tsx
+++ b/front-end/src/scenes/LandingPage.tsx
@@ -1,8 +1,11 @@
-import {Box, Button, Modal, TextField, Typography, styled} from '@mui/material'
-import * as React from 'react'
+import {useEffect} from 'react'
 import background from '../img/backgroundimage.png'
+import { abortRequest } from '../config/WebcallAPI'
 
 export default function LandingPage() {
+    useEffect(()=>{
+        abortRequest()
+    },[])
     return (
         <div>
             <img src={background} alt="background" />

--- a/front-end/src/scenes/asset_screener/AssetScreener.tsx
+++ b/front-end/src/scenes/asset_screener/AssetScreener.tsx
@@ -2,7 +2,7 @@ import SearchIcon from '@mui/icons-material/Search'
 import {Box, Button, IconButton, Paper, Tab, Tabs, TextField, useTheme} from '@mui/material'
 import {useEffect, useState} from 'react'
 import {useNavigate, useParams} from 'react-router-dom'
-import {assetScreener} from '../../config/WebcallAPI'
+import {abortRequest, assetScreener, getControllerSignal} from '../../config/WebcallAPI'
 import {tokens} from '../../theme'
 import AssetScreenerCategories from './AssetScreenerInterfaces/AssetScreenerCategories'
 import BasicInfo from './tabContents/BasicInfo'
@@ -21,6 +21,7 @@ const AssetScreener = () => {
     const [currentTicker, setCurrentTicker] = useState(ticker)
 
     useEffect(() => {
+        abortRequest()
         if (ticker) {
             setCurrentTicker(ticker)
             handleNewSearch(ticker)
@@ -47,7 +48,8 @@ const AssetScreener = () => {
         navigate({pathname: '/asset-screener', search: `${currentTicker}`})
         try {
             //use webcall API
-            const response = await fetch(assetScreener(ticker))
+            const signal = getControllerSignal()
+            const response = await fetch(assetScreener(ticker),{signal})
                 .then((response) => response.json())
                 .then((jsonResponse) => {
                     obj = jsonResponse

--- a/front-end/src/scenes/dashboard/AnalystCalls.tsx
+++ b/front-end/src/scenes/dashboard/AnalystCalls.tsx
@@ -1,20 +1,28 @@
-import {Box, useTheme} from '@mui/material'
-import Button from '@mui/material/Button'
-import React, {useContext} from 'react'
-import {ColorModeContext, tokens} from '../../theme'
+import {useTheme} from '@mui/material'
+import {useEffect, useState} from 'react'
 import AnalystCallTable from '../../components/table/AnalystCallTable'
+import { abortRequest } from '../../config/WebcallAPI'
 
 const AnalystCalls = () => {
     const theme = useTheme()
-    const colors = tokens(theme.palette.mode)
-    const colorMode = useContext(ColorModeContext)
-    return (
-        <>
+    const [displayAC, setDisplayAC] = useState(false)
+    useEffect(()=>{
+        abortRequest()
+        setDisplayAC(true)
+    },[])
+    if(displayAC){
+        return (
             <div>
                 <AnalystCallTable />
             </div>
-        </>
-    )
+        )
+    }
+    else{
+        return(
+            <>
+            </>
+        )
+    }
 }
 
 export default AnalystCalls

--- a/front-end/src/scenes/dashboard/Dashboard.tsx
+++ b/front-end/src/scenes/dashboard/Dashboard.tsx
@@ -4,7 +4,7 @@ import {useEffect, useState} from 'react'
 import Cookies from 'universal-cookie'
 import Watchlist from '../watchlist/Watchlist'
 import Searchbar from '../watchlist/stock/Searchbar'
-import {getUserWL} from '../../config/WebcallAPI'
+import {abortRequest, getControllerSignal, getUserWL} from '../../config/WebcallAPI'
 import AddTickersButton from '../watchlist/WL_Action_Buttons/Add_Tickers_Button'
 import CreateWLButton from '../watchlist/WL_Action_Buttons/Create_Button'
 import DeleteTickersButton from '../watchlist/WL_Action_Buttons/Delete_Tickers_Button'
@@ -13,8 +13,6 @@ import RenameWLButton from '../watchlist/WL_Action_Buttons/Rename_Button'
 
 const Dashboard = () => {
     const theme = useTheme()
-
-    const controller = new AbortController()
 
     const [userWatchlists, setUserWatchlists] = useState([])
     const [wl_name, set_wl_name] = useState('Select a Watchlist')
@@ -27,12 +25,16 @@ const Dashboard = () => {
 
     const cookies = new Cookies()
 
+    useEffect(()=>{
+        abortRequest()
+    },[])
+
     useEffect(() => {
         fetchUserWatchlists()
     }, [wlUpdatedToggle])
 
     async function fetchUserWatchlists() {
-        const signal = controller.signal
+        const signal = getControllerSignal()
         try {
             const response = await fetch(getUserWL(cookies.get('user_id')), {
                 signal,
@@ -130,7 +132,6 @@ const Dashboard = () => {
                 wlUpdated={wlUpdatedToggle}
                 wlDeleted={wlDeleted}
                 setWLDeleted={setWLDeleted}
-                controller={controller}
             />
         </Box>
     )

--- a/front-end/src/scenes/global/sidebar.tsx
+++ b/front-end/src/scenes/global/sidebar.tsx
@@ -11,12 +11,8 @@ import IsoIcon from '@mui/icons-material/Iso'
 import DeleteIcon from '@mui/icons-material/Delete'
 import MenuOutlinedIcon from '@mui/icons-material/MenuOutlined'
 import PhoneIcon from '@mui/icons-material/Phone'
-import Cookies from 'universal-cookie'
-import axios from 'axios'
 import {ShowChart} from '@mui/icons-material'
 import React from 'react'
-import ConfirmationModal from '../../components/ConfirmationModal'
-import AssetScreener from '../asset_screener/AssetScreener'
 
 type itemProps = {
     title: string

--- a/front-end/src/scenes/watchlist/WL_Action_Buttons/Add_Tickers_Button.tsx
+++ b/front-end/src/scenes/watchlist/WL_Action_Buttons/Add_Tickers_Button.tsx
@@ -1,5 +1,5 @@
 import {useState} from 'react'
-import {addTickersToWL} from '../../../config/WebcallAPI'
+import {addTickersToWL, getControllerSignal} from '../../../config/WebcallAPI'
 import {Box, Button, Modal, Typography, colors} from '@mui/material'
 import modalStyle from '../WatchlistStyles'
 import Searchbar from '../stock/Searchbar'
@@ -21,11 +21,14 @@ const AddTickersButton = (props: AddTickersButtonProps) => {
 
     async function addTickers(wlAddTickers: string) {
         handleClose()
-        const response = await fetch(addTickersToWL(wlAddTickers, props.wl_id, props.user_id), {}).then((response) => {
+        const signal = getControllerSignal()
+        const response = await fetch(addTickersToWL(wlAddTickers, props.wl_id, props.user_id), {signal}).then((response) => {
             response.json().then((json) => {
                 console.log(json)
                 props.wlUpdatedFunction(!props.wlUpdated)
             })
+        }).catch((err)=>{
+            
         })
     }
 

--- a/front-end/src/scenes/watchlist/WL_Action_Buttons/Create_Button.tsx
+++ b/front-end/src/scenes/watchlist/WL_Action_Buttons/Create_Button.tsx
@@ -1,5 +1,5 @@
 import {useState} from 'react'
-import {createWL} from '../../../config/WebcallAPI'
+import {createWL, getControllerSignal} from '../../../config/WebcallAPI'
 import {Box, Button, Modal, TextField, Typography} from '@mui/material'
 import modalStyle from '../WatchlistStyles'
 
@@ -18,11 +18,14 @@ const CreateWLButton = (props: CreateWLButtonProps) => {
 
     async function createWatchlist() {
         handleClose()
-        const response = await fetch(createWL(props.user_id, newWLName), {}).then((response) => {
+        const signal = getControllerSignal()
+        const response = await fetch(createWL(props.user_id, newWLName), {signal}).then((response) => {
             response.json().then((json) => {
                 console.log(json)
                 props.wlUpdatedFunction(!props.wlUpdated)
             })
+        }).catch((err)=>{
+            
         })
     }
 

--- a/front-end/src/scenes/watchlist/WL_Action_Buttons/Delete_Tickers_Button.tsx
+++ b/front-end/src/scenes/watchlist/WL_Action_Buttons/Delete_Tickers_Button.tsx
@@ -1,5 +1,5 @@
 import {useState} from 'react'
-import {delTickersFromWL} from '../../../config/WebcallAPI'
+import {delTickersFromWL, getControllerSignal} from '../../../config/WebcallAPI'
 import {Box, Button, Modal, Typography, colors} from '@mui/material'
 import modalStyle from '../WatchlistStyles'
 import Searchbar from '../stock/Searchbar'
@@ -22,11 +22,14 @@ const DeleteTickersButton = (props: DeleteTickersButtonProps) => {
 
     async function delTickersFromWatchlist(wlDelTickers: string) {
         handleClose()
-        const response = await fetch(delTickersFromWL(wlDelTickers, props.wl_id, props.user_id), {}).then((response) => {
+        const signal = getControllerSignal()
+        const response = await fetch(delTickersFromWL(wlDelTickers, props.wl_id, props.user_id), {signal}).then((response) => {
             response.json().then((json) => {
                 console.log(json)
                 props.wlUpdatedFunction(!props.wlUpdated)
             })
+        }).catch((err)=>{
+            
         })
     }
 

--- a/front-end/src/scenes/watchlist/WL_Action_Buttons/Delete_WL_Button.tsx
+++ b/front-end/src/scenes/watchlist/WL_Action_Buttons/Delete_WL_Button.tsx
@@ -1,5 +1,5 @@
 import {useState} from 'react'
-import {deleteWL} from '../../../config/WebcallAPI'
+import {deleteWL, getControllerSignal} from '../../../config/WebcallAPI'
 import {Box, Button, Modal, Typography, colors} from '@mui/material'
 import modalStyle from '../WatchlistStyles'
 
@@ -19,12 +19,15 @@ const DeleteWLButton = (props: DeleteWLButtonProps) => {
 
     async function delWatchlist() {
         handleClose()
-        const response = await fetch(deleteWL(props.wl_id, props.user_id), {}).then((response) => {
+        const signal = getControllerSignal()
+        const response = await fetch(deleteWL(props.wl_id, props.user_id), {signal}).then((response) => {
             response.json().then((json) => {
                 console.log(json)
                 props.wlUpdatedFunction(!props.wlUpdated)
                 props.setWLDeleted(true)
             })
+        }).catch((err)=>{
+            
         })
     }
 

--- a/front-end/src/scenes/watchlist/WL_Action_Buttons/Rename_Button.tsx
+++ b/front-end/src/scenes/watchlist/WL_Action_Buttons/Rename_Button.tsx
@@ -1,5 +1,5 @@
 import {useState} from 'react'
-import {renameWL} from '../../../config/WebcallAPI'
+import {getControllerSignal, renameWL} from '../../../config/WebcallAPI'
 import {Box, Button, Modal, TextField, Typography, colors} from '@mui/material'
 import modalStyle from '../WatchlistStyles'
 
@@ -21,12 +21,15 @@ const RenameWLButton = (props: RenameWLProps) => {
 
     async function renameWatchlist() {
         handleClose()
-        const response = await fetch(renameWL(props.wl_id, props.user_id, newName), {}).then((response) => {
+        const signal = getControllerSignal()
+        const response = await fetch(renameWL(props.wl_id, props.user_id, newName), {signal}).then((response) => {
             response.json().then((json) => {
                 console.log(json)
                 props.wlUpdatedFunction(!props.wlUpdated)
                 props.newName(newName)
             })
+        }).catch((err)=>{
+            
         })
     }
 


### PR DESCRIPTION
Implemented abort controller for all of our fetch requests in which we needed to interrupt them. Also cleaned up some unused imports and fixed an issue with Insider Trades Table where each table row needed a unique key id according to the google chrome warning I was seeing.